### PR TITLE
Fix notifyUpdated usage

### DIFF
--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-git_subproject(Servus https://github.com/HBPVIS/Servus.git 62873a5)
+git_subproject(Servus https://github.com/HBPVIS/Servus.git 9fb8f08)

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -2,6 +2,8 @@
 
 # git master
 
+* [48](https://github.com/HBPVIS/ZeroBuf/pull/48):
+  Fix notifyUpdated usage. Generate doxygen documentation
 * [49](https://github.com/HBPVIS/ZeroBuf/pull/49):
   Added the exit event
 * [52](https://github.com/HBPVIS/ZeroBuf/pull/52):

--- a/zerobuf/Vector.h
+++ b/zerobuf/Vector.h
@@ -47,7 +47,7 @@ public:
     /** @return The pointer to the current allocation of the vector */
     const T* data() const { return _alloc->template getDynamic< T >( _index ); }
 
-    /** @return true if the two vectors of buitins are identical. */
+    /** @return true if the two vectors of builtins are identical. */
     bool operator == ( const Vector& rhs ) const;
     /** @return false if the two vectors are identical. */
     bool operator != ( const Vector& rhs ) const;

--- a/zerobuf/Zerobuf.h
+++ b/zerobuf/Zerobuf.h
@@ -34,9 +34,6 @@ public:
     /** @return the number of dynamics fields of this object. */
     virtual size_t getZerobufNumDynamics() const = 0;
 
-    /** Called if any data in this object is about to change. */
-    virtual void notifyChanging() {}
-
     /**
      * Remove unused holes from the zerobuf.
      *
@@ -72,6 +69,9 @@ public:
 protected:
     ZEROBUF_API explicit Zerobuf( AllocatorPtr alloc ); // takes ownership of alloc
     ZEROBUF_API virtual ~Zerobuf();
+
+    /** Called if any data in this object has changed. */
+    ZEROBUF_API virtual void notifyChanged() {}
 
     // used by generated ZeroBuf objects
     ZEROBUF_API const Allocator& getAllocator() const;


### PR DESCRIPTION
Notify changes by calling notifyUpdated()
after the object has been changed (and not before).
Remove notifyChanging().

Generate doxygen documentation automatically for setters and
reference getters.