### PR TITLE
Implement servus::Serializable::getSchema()

### DIFF
--- a/.gitsubprojects
+++ b/.gitsubprojects
@@ -1,2 +1,2 @@
 # -*- mode: cmake -*-
-git_subproject(Servus https://github.com/HBPVIS/Servus.git 9fb8f08)
+git_subproject(Servus https://github.com/HBPVIS/Servus.git 001588d)

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
   - brew update
   - brew outdated cmake || brew upgrade cmake
   - brew install cppcheck doxygen ninja
-  - brew install python
   - pip install pyparsing
 script:
   - mkdir $BUILD_TYPE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (c) HBP 2015 Grigori Chevtchenko <grigori.chevtchenko@epfl.ch>
+# Copyright (c) HBP 2015-2016 Grigori Chevtchenko <grigori.chevtchenko@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(ZeroBuf VERSION 0.3.0)
-set(ZeroBuf_VERSION_ABI 2)
+project(ZeroBuf VERSION 0.4.0)
+set(ZeroBuf_VERSION_ABI 3)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
   ${PROJECT_SOURCE_DIR}/zerobuf/share/zerobuf/CMake

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -1,5 +1,12 @@
 # Changelog {#Changelog}
 
+# git master
+
+* [65](https://github.com/HBPVIS/ZeroBuf/pull/65):
+  * JSON schema generated from FBS, available in ZeroBuf::getSchema() and ZeroBuf::ZEROBUF_SCHEMA
+  * enum class for enums instead of 'old' enums; breaks existing enum names
+  * fix wrong JSON value for empty arrays (was 'null', is '[]' now)
+
 # Release 0.3 (30-06-2016)
 
 * [59](https://github.com/HBPVIS/ZeroBuf/pull/59):

--- a/tests/jsonSerialization.cpp
+++ b/tests/jsonSerialization.cpp
@@ -1,12 +1,12 @@
 
-/* Copyright (c) 2015, Human Brain Project
- *                     Daniel Nachbaur <danielnachbaur@epfl.ch>
+/* Copyright (c) 2015-2016, Human Brain Project
+ *                          Daniel Nachbaur <danielnachbaur@epfl.ch>
  */
 
 #define BOOST_TEST_MODULE jsonSerialization
 
 #include <boost/test/unit_test.hpp>
-
+#include <iostream>
 #include "serialization.h"
 
 const std::string expectedNestedJson( "{\n"
@@ -21,7 +21,7 @@ const std::string expectedJson( "{\n"
                                 "   \"doublearray\" : [ 1, 1, 2, 3 ],\n"
                                 "   \"doubledynamic\" : [ 1, 1, 2, 3 ],\n"
                                 "   \"doublevalue\" : 42,\n"
-                                "   \"enumeration\" : 1,\n"
+                                "   \"enumeration\" : \"SECOND\",\n"
                                 "   \"enumerations\" : [ 0, 1 ],\n"
                                 "   \"falseBool\" : false,\n"
                                 "   \"floatarray\" : [ 1, 1, 2, 3 ],\n"
@@ -203,4 +203,109 @@ BOOST_AUTO_TEST_CASE(zerobufFromJSON)
     test::TestSchema object;
     object.fromJSON( expectedJson );
     checkTestObject( object );
+}
+
+BOOST_AUTO_TEST_CASE(enum_string_conversion)
+{
+    test::TestEnum testEnum = test::TestEnum::FIRST;
+    BOOST_CHECK_EQUAL( test::to_string( testEnum ), "FIRST" );
+    testEnum = test::from_string( "SECOND" );
+    BOOST_CHECK_EQUAL( testEnum, test::TestEnum::SECOND );
+    BOOST_CHECK_NO_THROW( std::cout << testEnum << std::endl );
+
+    BOOST_CHECK_THROW( test::from_string( "wrong" ), std::runtime_error );
+}
+
+BOOST_AUTO_TEST_CASE(json_schema_empty)
+{
+    BOOST_CHECK_EQUAL( test::TestEmpty::ZEROBUF_SCHEMA(),
+                       "{\"$schema\": \"http://json-schema.org/schema#\", "
+                       "\"additionalProperties\": false, "
+                       "\"description\": \"Class TestEmpty of namespace ['test']\", "
+                       "\"title\": \"TestEmpty\", "
+                       "\"type\": \"object\"}" );
+}
+
+BOOST_AUTO_TEST_CASE(json_schema_nested)
+{
+    BOOST_CHECK_EQUAL( test::TestNested::ZEROBUF_SCHEMA(),
+                       "{\"$schema\": \"http://json-schema.org/schema#\", "
+                       "\"additionalProperties\": false, "
+                       "\"description\": \"Class TestNested of namespace ['test']\", "
+                       "\"properties\": {"
+                       "\"intvalue\": {\"type\": \"integer\"}, "
+                       "\"uintvalue\": {\"type\": \"integer\"}}, "
+                       "\"title\": \"TestNested\", "
+                       "\"type\": \"object\"}" );
+}
+
+BOOST_AUTO_TEST_CASE(json_schema_dynamic)
+{
+    BOOST_CHECK_EQUAL( test::TestDynamic::ZEROBUF_SCHEMA(),
+                       "{\"$schema\": \"http://json-schema.org/schema#\", "
+                       "\"additionalProperties\": false, "
+                       "\"description\": \"Class TestDynamic of namespace ['test']\", "
+                       "\"properties\": {"
+                       "\"intvalue\": {\"type\": \"integer\"}, "
+                       "\"name\": {\"type\": \"string\"}}, "
+                       "\"title\": \"TestDynamic\", "
+                       "\"type\": \"object\"}" );
+}
+
+BOOST_AUTO_TEST_CASE(json_schema_nested_zerobuf)
+{
+    BOOST_CHECK_EQUAL( test::TestNestedZerobuf::ZEROBUF_SCHEMA(),
+                       "{\"$schema\": \"http://json-schema.org/schema#\", "
+                       "\"additionalProperties\": false, "
+                       "\"description\": \"Class TestNestedZerobuf of namespace ['test']\", "
+                       "\"properties\": {"
+                         "\"dynamic\": {"
+                           "\"$schema\": \"http://json-schema.org/schema#\", "
+                           "\"additionalProperties\": false, "
+                           "\"description\": \"Class TestDynamic of namespace ['test']\", "
+                           "\"properties\": {"
+                             "\"intvalue\": {\"type\": \"integer\"}, "
+                             "\"name\": {\"type\": \"string\"}}, "
+                           "\"title\": \"TestDynamic\", "
+                           "\"type\": \"object\"}, "
+                         "\"nest\": {"
+                           "\"$schema\": \"http://json-schema.org/schema#\", "
+                           "\"additionalProperties\": false, "
+                           "\"description\": \"Class TestNested of namespace ['test']\", "
+                           "\"properties\": {"
+                             "\"intvalue\": {\"type\": \"integer\"}, "
+                             "\"uintvalue\": {\"type\": \"integer\"}}, "
+                           "\"title\": \"TestNested\", "
+                           "\"type\": \"object\"}, "
+                         "\"nested\": {"
+                           "\"items\": {"
+                             "\"$schema\": \"http://json-schema.org/schema#\", "
+                             "\"additionalProperties\": false, "
+                             "\"description\": \"Class TestNested of namespace ['test']\", "
+                             "\"properties\": {"
+                               "\"intvalue\": {\"type\": \"integer\"}, "
+                               "\"uintvalue\": {\"type\": \"integer\"}}, "
+                             "\"title\": \"TestNested\", "
+                             "\"type\": \"object\"}, "
+                           "\"type\": \"array\"}}, "
+                         "\"title\": \"TestNestedZerobuf\", "
+                         "\"type\": \"object\"}" );
+}
+
+BOOST_AUTO_TEST_CASE(json_schema_enum)
+{
+    BOOST_CHECK_EQUAL( test::TestEnumTable::ZEROBUF_SCHEMA(),
+                       "{\"$schema\": \"http://json-schema.org/schema#\", "
+                       "\"additionalProperties\": false, "
+                       "\"description\": \"Class TestEnumTable of namespace ['test']\", "
+                       "\"properties\": {"
+                         "\"value\": {"
+                           "\"$schema\": \"http://json-schema.org/schema#\", "
+                           "\"additionalProperties\": false, "
+                           "\"description\": \"Enum TestEnum of type uint\", "
+                           "\"enum\": [\"FIRST\", \"SECOND\", \"THIRD_UNDERSCORE\"], "
+                           "\"title\": \"TestEnum\", "
+                           "\"type\": \"string\"}}, "
+                       "\"title\": \"TestEnumTable\", "
+                       "\"type\": \"object\"}" );
 }

--- a/tests/serialization.h
+++ b/tests/serialization.h
@@ -63,9 +63,9 @@ test::TestSchema getTestObject()
     object.setBoolvalue( true );
     object.setStringvalue( "testmessage" );
 
-    object.setEnumeration( test::TestEnum_SECOND );
-    const std::vector<test::TestEnum> testEnums = { test::TestEnum_FIRST,
-                                                    test::TestEnum_SECOND };
+    object.setEnumeration( test::TestEnum::SECOND );
+    const std::vector<test::TestEnum> testEnums = { test::TestEnum::FIRST,
+                                                    test::TestEnum::SECOND };
     object.setEnumerations( testEnums );
 
     int32_t intMagic = 42;
@@ -136,10 +136,10 @@ void checkTestObject( const test::TestSchema& object )
     TESTVALUES(int64_t, Int64_t);
     BOOST_CHECK( object.getBoolvalue( ));
     BOOST_CHECK_EQUAL( object.getStringvalueString(), "testmessage" );
-    BOOST_CHECK_EQUAL( object.getEnumeration(), test::TestEnum_SECOND );
+    BOOST_CHECK_EQUAL( object.getEnumeration(), test::TestEnum::SECOND );
 
-    const std::vector<test::TestEnum> testEnums = { test::TestEnum_FIRST,
-                                                    test::TestEnum_SECOND };
+    const std::vector<test::TestEnum> testEnums = { test::TestEnum::FIRST,
+                                                    test::TestEnum::SECOND };
     const std::vector<test::TestEnum>& result = object.getEnumerationsVector();
     BOOST_CHECK_EQUAL_COLLECTIONS( testEnums.begin(), testEnums.end(),
                                    result.begin(), result.end( ));

--- a/tests/testSchema.fbs
+++ b/tests/testSchema.fbs
@@ -26,6 +26,10 @@ enum TestEnum : uint {
   THIRD_UNDERSCORE
 }
 
+table TestEnumTable {
+  value: TestEnum;
+}
+
 table TestSchema {
   intvalue: int;
   uintvalue: uint = 42;

--- a/zerobuf/Vector.h
+++ b/zerobuf/Vector.h
@@ -282,6 +282,7 @@ Vector< T >::toJSON( Json::Value& json, const typename std::enable_if<
                         std::is_base_of< Zerobuf, Q >::value, Q >::type* ) const
 {
     const size_t size_ = size();
+    zerobuf::emptyJSONArray( json ); // return [] instead of null if array is empty
     for( size_t i = 0; i < size_; ++i )
         zerobuf::toJSON( static_cast< const Zerobuf& >(( *this )[ i ]),
                          getJSONField( json, i ));
@@ -292,6 +293,7 @@ Vector< T >::toJSON( Json::Value& json, const typename std::enable_if<
                        !std::is_base_of< Zerobuf, Q >::value, Q >::type* ) const
 {
     const size_t size_ = size();
+    zerobuf::emptyJSONArray( json ); // return [] instead of null if array is empty
     for( size_t i = 0; i < size_; ++i )
         zerobuf::toJSON( (*this)[i], getJSONField( json, i ));
 }

--- a/zerobuf/json.cpp
+++ b/zerobuf/json.cpp
@@ -61,6 +61,11 @@ template<> ZEROBUF_INL void toJSON( const uint128_t& value, Json::Value& json )
     json[ "low" ] = Json::UInt64( value.low( ));
 }
 
+void emptyJSONArray( Json::Value& value )
+{
+    value = Json::Value( Json::arrayValue );
+}
+
 void fromJSON( const Json::Value& json, Zerobuf& zerobuf )
 {
     zerobuf._parseJSON( json );

--- a/zerobuf/json.h
+++ b/zerobuf/json.h
@@ -29,6 +29,7 @@ ZEROBUF_API void toJSON( const Zerobuf& zerobuf, Json::Value& json );
 ZEROBUF_API std::string fromJSONBinary( const Json::Value& json );
 ZEROBUF_API void toJSONBinary( const uint8_t* data, const size_t size,
                                Json::Value& json );
+ZEROBUF_API void emptyJSONArray( Json::Value& value );
 /** @endcond */
 }
 


### PR DESCRIPTION
* emit JSON schema from FBS in zerobufCxx.py
* create enum class for enums instead of 'old' enums; breaks existing enum names
* fix wrong JSON value for empty arrays (was 'null', is '[]' now)