### PR TITLE
Improved zerobufCxx.py for ipp files generation

### DIFF
--- a/bin/zerobufCxx.py
+++ b/bin/zerobufCxx.py
@@ -15,8 +15,6 @@ import re
 import sys
 from collections import namedtuple, OrderedDict
 
-inline_implementation = False
-
 TypeDescription = namedtuple("TypeDescription", "size cxxtype")
 DEFAULT_TYPES = {"int" : TypeDescription(4, "int32_t"),
                  "uint" : TypeDescription(4, "uint32_t"),
@@ -206,8 +204,6 @@ class Function():
         impl_function = re.sub(r" = [0-9\.f]+ ", " ", impl_function) # remove default params
 
         next_line(file)
-
-        global inline_implementation
         
         if self.ret_val: # '{}'-less body
             add_before_inline = ""

--- a/bin/zerobufCxx.py
+++ b/bin/zerobufCxx.py
@@ -208,7 +208,7 @@ class Function():
         if self.ret_val: # '{}'-less body
             add_before_inline = ""
             add_after_inline = ""
-            if inline_implementation is True:
+            if inline_implementation:
                 add_before_inline = "inline " if not (self.ret_val.startswith("template<>") or has_final) else ""
                 add_after_inline = "inline " if self.ret_val.startswith("template<>") and not (has_final) else ""
             
@@ -223,7 +223,7 @@ class Function():
             file.write('}')
         else:      # ctor '[initializer list]{ body }'
             add_inline = ""
-            if inline_implementation is True:
+            if inline_implementation:
                 add_inline = "inline "
             file.write('{0}{1}{2}'.format(add_inline, (classname + '::') if classname else '',
                                         impl_function))


### PR DESCRIPTION
Hello, I'm Gonzalo Bayo, from the group working back in URJC/UPM with Pablo Toharia. Right now I'm trying to use **ZeroBuf** in a custom C++ project in Windows and the generated ipp files don't compile if we use this library in more than one project. Visual Studio compiler reject the compilation with an LNK2005( function/method already defined ).
Modifying the _zerobufCxx.py_ file by adding the "inline" keyword before function definitions on ipp files could be an option to fix this and make errors disappear.
Regards